### PR TITLE
[AC-64] Fix activity copy limit validation

### DIFF
--- a/src/stream-net-tests/BatchTests.cs
+++ b/src/stream-net-tests/BatchTests.cs
@@ -51,6 +51,14 @@ namespace stream_net_tests
             {
                 await this._client.Batch.FollowMany(null, 1001);
             });
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                await this._client.Batch.FollowMany(new Stream.Follow[] { new Stream.Follow("user:1", "user:2") }, 0);
+            });
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                await this._client.Batch.FollowMany(new Stream.Follow[] { new Stream.Follow("user:1", "user:2") }, 1000);
+            });
         }
     }
 }

--- a/src/stream-net-tests/FeedTests.cs
+++ b/src/stream-net-tests/FeedTests.cs
@@ -91,6 +91,26 @@ namespace stream_net_tests
             {
                 _feed.FollowFeed(_feed).GetAwaiter().GetResult();
             });
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                var feed = _client.Feed("flat", Guid.NewGuid().ToString());
+                await _feed.FollowFeed(feed, -1);
+            });
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                var feed = _client.Feed("flat", Guid.NewGuid().ToString());
+                await _feed.FollowFeed(feed, 1001);
+            });
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                var feed = _client.Feed("flat", Guid.NewGuid().ToString());
+                await _feed.FollowFeed(feed, 0);
+            });
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                var feed = _client.Feed("flat", Guid.NewGuid().ToString());
+                await _feed.FollowFeed(feed, 1000);
+            });
         }
 
         [Test]

--- a/src/stream-net/BatchOperations.cs
+++ b/src/stream-net/BatchOperations.cs
@@ -49,8 +49,8 @@ namespace Stream
 
         public async Task FollowMany(IEnumerable<Follow> follows, int activityCopyLimit = StreamClient.ActivityCopyLimitDefault)
         {
-            if (activityCopyLimit < 1)
-                throw new ArgumentOutOfRangeException("activityCopyLimit", "Activity copy limit must be greater than 0");
+            if (activityCopyLimit < 0)
+                throw new ArgumentOutOfRangeException("activityCopyLimit", "Activity copy limit must be greater than or equal to 0");
             if (activityCopyLimit > StreamClient.ActivityCopyLimitMax)
                 throw new ArgumentOutOfRangeException("activityCopyLimit", string.Format("Activity copy limit must be less than or equal to {0}", StreamClient.ActivityCopyLimitMax));
 

--- a/src/stream-net/StreamFeed.cs
+++ b/src/stream-net/StreamFeed.cs
@@ -270,8 +270,8 @@ namespace Stream
                 throw new ArgumentNullException("feedToFollow", "Must have a feed to follow");
             if (feedToFollow.FeedTokenId == this.FeedTokenId)
                 throw new ArgumentException("Cannot follow myself");
-            if (activityCopyLimit < 1)
-                throw new ArgumentOutOfRangeException("activityCopyLimit", "Activity copy limit must be greater than 0");
+            if (activityCopyLimit < 0)
+                throw new ArgumentOutOfRangeException("activityCopyLimit", "Activity copy limit must be greater than or equal to 0");
             if (activityCopyLimit > StreamClient.ActivityCopyLimitMax)
                 throw new ArgumentOutOfRangeException("activityCopyLimit", string.Format("Activity copy limit must be less than or equal to {0}", StreamClient.ActivityCopyLimitMax));
 


### PR DESCRIPTION
The old validation failed if `activity_copy_limit` == 0