### PR TITLE
Allow StreamClient to connect using UserSessionToken.

### DIFF
--- a/src/stream-net/StreamClientToken.cs
+++ b/src/stream-net/StreamClientToken.cs
@@ -1,0 +1,97 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Stream
+{
+    public interface IStreamClientToken
+    {
+        string CreateUserSessionToken(string userId, IDictionary<string, object> extraData = null);
+
+        string For(object payload);
+    }
+
+    public static class StreamClientToken
+    {
+        public static IStreamClientToken For(string apiSecretOrToken)
+        {
+            return apiSecretOrToken.Contains(".")
+                ? (IStreamClientToken) new StreamApiSessionToken(apiSecretOrToken)
+                : (IStreamClientToken) new StreamApiSecret(apiSecretOrToken);
+        }
+    }
+
+    public class StreamApiSessionToken : IStreamClientToken
+    {
+        private readonly string _sessionToken;
+
+        public StreamApiSessionToken(string sessionToken)
+        {
+            _sessionToken = sessionToken;
+        }
+
+        public string CreateUserSessionToken(string userId, IDictionary<string, object> extraData = null)
+        {
+            throw new InvalidOperationException("Clients connecting using a user session token cannot create additional user session tokens");
+        }
+
+        public string For(object payload)
+        {
+            return _sessionToken;
+        }
+    }
+
+    public class StreamApiSecret : IStreamClientToken
+    {
+        private readonly string _apiSecret;
+
+        public StreamApiSecret(string apiSecret)
+        {
+            _apiSecret = apiSecret;
+        }
+
+        private static string Base64UrlEncode(byte[] input)
+        {
+            return Convert.ToBase64String(input)
+                    .Replace('+', '-')
+                    .Replace('/', '_')
+                    .Trim('=');
+        }
+
+        public string CreateUserSessionToken(string userId, IDictionary<string, object> extraData = null)
+        {
+            var payload = new Dictionary<string, object>
+            {
+                {"user_id", userId}
+            };
+            if (extraData != null)
+            {
+                extraData.ForEach(x => payload[x.Key] = x.Value);
+            }
+            return For(payload);
+        }
+
+        public string For(object payload)
+        {
+            var segments = new List<string>();
+
+            byte[] headerBytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(StreamClient.JWTHeader));
+            byte[] payloadBytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(payload));
+
+            segments.Add(Base64UrlEncode(headerBytes));
+            segments.Add(Base64UrlEncode(payloadBytes));
+
+            var stringToSign = string.Join(".", segments.ToArray());
+            var bytesToSign = Encoding.UTF8.GetBytes(stringToSign);
+
+            using (var sha = new HMACSHA256(Encoding.UTF8.GetBytes(_apiSecret)))
+            {
+                byte[] signature = sha.ComputeHash(bytesToSign);
+                segments.Add(Base64UrlEncode(signature));
+            }
+            return string.Join(".", segments.ToArray());
+        }
+    }
+}


### PR DESCRIPTION
PR for [issue 39](https://github.com/GetStream/stream-net/issues/39).

Using this code I was able to retrieve feed activities using a client authenticated with a user session token as shown below:

```c#
// Executed on the server
var serverConnection = new StreamClient(apiKey, apiSecret);
var clientToken = serverConnection.CreateUserSessionToken(userId);

// Just to verify that the 'server' can retrieve the users feed
var serverResponse = await serverConnection.Feed(feedSlug, userId).GetActivities(); // executes correctly

display($"Activites retrieved on server: {serverResponse.Count()}");

var clientConnection = new StreamClient(apiKey, clientToken);
var clientResponse = await clientConnection.Feed(feedSlug, userId).GetActivities(); // previously failed with "signature is invalid" now succeeds

display($"Activites retrieved on client: {clientResponse.Count()}");
```