### PR TITLE
fix: rename override -> override_existing in UserBatch.cs

### DIFF
--- a/src/UsersBatch.cs
+++ b/src/UsersBatch.cs
@@ -22,7 +22,7 @@ namespace Stream
             var body = new Dictionary<string, object>
             {
                 { "users", users },
-                { "override", overrideExisting },
+                { "override_existing", overrideExisting },
             };
             var request = _client.BuildAppRequest("users/", HttpMethod.Post);
             request.SetJsonBody(StreamJsonConverter.SerializeObject(body));


### PR DESCRIPTION
"override" is the incorrect variable name when using UpsertUsersAsync api. Instead "override_existing" should be used