### PR TITLE
[MOD-0]Errors encountered while flagging users are now returned instead of being ignored. The flagUser method now requires a mandatory flaggingUserID parameter.

### DIFF
--- a/src/IModeration.cs
+++ b/src/IModeration.cs
@@ -6,7 +6,7 @@ namespace Stream
 {
     public interface IModeration
     {
-        Task<ResponseBase> FlagUserAsync(string flaggedUserId, string reason, IDictionary<string, object> options = null);
+        Task<ResponseBase> FlagUserAsync(string flaggingUserID, string flaggedUserId, string reason, IDictionary<string, object> options = null);
 
         Task<ResponseBase> FlagActivityAsync(string entityId, string entityCreatorId, string reason,
             IDictionary<string, object> options = null);

--- a/src/Moderation.cs
+++ b/src/Moderation.cs
@@ -19,9 +19,9 @@ namespace Stream
             _client = client;
         }
 
-        public async Task<ResponseBase> FlagUserAsync(string flaggedUserID, string reason, IDictionary<string, object> options = null)
+        public async Task<ResponseBase> FlagUserAsync(string flaggingUserID, string flaggedUserID, string reason, IDictionary<string, object> options = null)
         {
-            return await FlagAsync("stream:user", flaggedUserID, string.Empty, reason, options);
+            return await FlagAsync("stream:user", flaggedUserID, flaggingUserID, reason, options);
         }
 
         public async Task<ResponseBase> FlagActivityAsync(string entityId, string entityCreatorID, string reason, IDictionary<string, object> options = null)
@@ -45,7 +45,7 @@ namespace Stream
 
             var response = await _client.MakeRequestAsync(request);
 
-            if (response.StatusCode > HttpStatusCode.Accepted)
+            if (response.StatusCode == HttpStatusCode.Created)
                 return StreamJsonConverter.DeserializeObject<ResponseBase>(response.Content);
 
             throw StreamException.FromResponse(response);

--- a/src/Moderation.cs
+++ b/src/Moderation.cs
@@ -45,7 +45,10 @@ namespace Stream
 
             var response = await _client.MakeRequestAsync(request);
 
-            return StreamJsonConverter.DeserializeObject<ResponseBase>(response.Content);
+            if (response.StatusCode > HttpStatusCode.Accepted)
+                return StreamJsonConverter.DeserializeObject<ResponseBase>(response.Content);
+
+            throw StreamException.FromResponse(response);
         }
     }
 }

--- a/tests/ModerationTests.cs
+++ b/tests/ModerationTests.cs
@@ -68,27 +68,27 @@ namespace StreamNetTests
         [Test]
         public async Task TestFlagUser()
         {
-            var userId = Guid.NewGuid().ToString();
+            var userId = "flagginguser";
             var userData = new Dictionary<string, object>
             {
                 { "field", "value" },
                 { "is_admin", true },
             };
 
-            var u = await Client.Users.AddAsync(userId, userData);
+            var u = await Client.Users.AddAsync(userId, userData, true);
 
             Assert.NotNull(u);
             Assert.NotNull(u.CreatedAt);
             Assert.NotNull(u.UpdatedAt);
 
-            var response = await Client.Moderation.FlagUserAsync(userId, "blood");
+            var response = await Client.Moderation.FlagUserAsync(userId, "flagged-user", "blood");
             Assert.NotNull(response);
         }
 
         [Test]
         public async Task TestFlagUserError()
         {
-            Assert.ThrowsAsync<StreamException>(async () => await Client.Moderation.FlagUserAsync(string.Empty, "blood"));
+            Assert.ThrowsAsync<StreamException>(async () => await Client.Moderation.FlagUserAsync("", string.Empty, "blood"));
         }
 
         [Test]

--- a/tests/ModerationTests.cs
+++ b/tests/ModerationTests.cs
@@ -63,7 +63,6 @@ namespace StreamNetTests
 
             Assert.AreEqual("complete", response.Status);
             Assert.AreEqual("remove", response.RecommendedAction);
-
         }
 
         [Test]
@@ -84,6 +83,12 @@ namespace StreamNetTests
 
             var response = await Client.Moderation.FlagUserAsync(userId, "blood");
             Assert.NotNull(response);
+        }
+
+        [Test]
+        public async Task TestFlagUserError()
+        {
+            Assert.ThrowsAsync<StreamException>(async () => await Client.Moderation.FlagUserAsync(string.Empty, "blood"));
         }
 
         [Test]


### PR DESCRIPTION
Errors encountered while flagging users are now returned instead of being ignored. The flagUser method now requires a mandatory flaggingUserID parameter.







