### PR TITLE
Bug report in form of reproducable code - Removing activities doesn't remove completely?

### DIFF
--- a/tests/ActivityTests/RemoveActivityTests.cs
+++ b/tests/ActivityTests/RemoveActivityTests.cs
@@ -49,7 +49,7 @@ namespace StreamNetTests
 
             await this.UserFeed.RemoveActivityAsync(fid, true);
 
-            activities = (await this.UserFeed.GetActivitiesAsync(0, 1)).Results;
+            activities = (await Client.Batch.GetActivitiesByIdAsync([response.Id])).Results;
             Assert.AreEqual(0, activities.Count());
         }
     }


### PR DESCRIPTION
Hi Getstream team, I've changed one of your integration tests to show an unexpected thing for me.

The expected behaviour for me is that when calling `UserFeed.RemoveActivityAsync(fid, true)`, the activity should be removed from Getstream.

However, if we use Client.Batch.GetActivitiesByIdAsync method, the removed activity will return, and the test will fail.

I use Client.Batch.GetActivitiesByIdAsync to know whether an activity exists or not. It's a very useful method to make sure I'm not adding a post that already exists.

Could you guide me on any documentation to hard-delete a post, so that it doesn't come back from Client.Batch.GetActivitiesByIdAsync?