### PR TITLE
Add your own HTTP handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,16 @@ var imageupload = await client.Images.UploadAsync(stream, name, contentType);
 var og = await client.OgAsync("https://google.com");
 ```
 
+### Custom HTTP handlers
+
+Add your own [`DelegatingHandler`](https://learn.microsoft.com/dotnet/api/system.net.http.delegatinghandler) to observe or decorate every request the client makes: log calls, add tracing, or read response headers the SDK does not surface, such as the [rate limit headers](https://getstream.io/docs/platform/rate-limits/). The first handler in the list is the outermost one, so it sees the request first and the response last.
+
+```c#
+var options = new StreamClientOptions();
+options.HttpHandlers.Add(new MyLoggingHandler()); // your DelegatingHandler subclass
+var client = new StreamClient("YOUR_API_KEY", "API_KEY_SECRET", options);
+```
+
 ## ✍️ Contributing
 
 We welcome code changes that improve this library or fix a problem, please make sure to follow all best practices and add tests if applicable before submitting a Pull Request on Github. We are very happy to merge your code in the official repository. Make sure to sign our [Contributor License Agreement (CLA)](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) first. See our [license file](./LICENSE) for more details.

--- a/src/Rest/RestClient.cs
+++ b/src/Rest/RestClient.cs
@@ -1,5 +1,7 @@
 ﻿using Stream.Utils;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -12,17 +14,32 @@ namespace Stream.Rest
     internal class RestClient
     {
         private static readonly MediaTypeWithQualityHeaderValue _jsonAcceptHeader = new MediaTypeWithQualityHeaderValue("application/json");
-        private static readonly HttpClient _client = new HttpClient();
+        private static readonly HttpClient _defaultClient = new HttpClient();
+        private readonly HttpClient _client;
         private readonly Uri _baseUrl;
         private readonly TimeSpan _timeout;
 
-        internal RestClient(Uri baseUrl, TimeSpan timeout)
+        internal RestClient(Uri baseUrl, TimeSpan timeout, HttpClient client = null)
         {
 #if OLD_TLS_HANDLING
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 #endif
             _baseUrl = baseUrl;
             _timeout = timeout;
+            _client = client ?? _defaultClient;
+        }
+
+        internal static HttpClient CreateClient(IEnumerable<DelegatingHandler> handlers)
+        {
+            HttpMessageHandler pipeline = new HttpClientHandler();
+
+            foreach (var handler in handlers.Reverse())
+            {
+                handler.InnerHandler = pipeline;
+                pipeline = handler;
+            }
+
+            return new HttpClient(pipeline);
         }
 
         private HttpRequestMessage BuildRequestMessage(HttpMethod method, Uri url, RestRequest request)

--- a/src/StreamClient.cs
+++ b/src/StreamClient.cs
@@ -64,7 +64,8 @@ namespace Stream
                 string.Format(BaseUrlFormat, GetRegion(_options.Location)) :
                 stream_url, UriKind.Absolute);
 
-            _client = new RestClient(url, TimeSpan.FromMilliseconds(_options.Timeout));
+            var httpClient = _options.HttpHandlers.Count > 0 ? RestClient.CreateClient(_options.HttpHandlers) : null;
+            _client = new RestClient(url, TimeSpan.FromMilliseconds(_options.Timeout), httpClient);
 
             var assemblyVersion = typeof(StreamClient).GetTypeInfo().Assembly.GetName().Version;
             Version = assemblyVersion.ToString(3);
@@ -75,7 +76,7 @@ namespace Stream
             Reactions = new Reactions(this);
             Users = new Users(this);
             Moderation = new Moderation(this);
-            var personalization = new RestClient(GetBasePersonalizationUrl(), TimeSpan.FromMilliseconds(_options.PersonalizationTimeout));
+            var personalization = new RestClient(GetBasePersonalizationUrl(), TimeSpan.FromMilliseconds(_options.PersonalizationTimeout), httpClient);
             Personalization = new Personalization(new StreamClient(_apiKey, _streamClientToken, personalization, _options));
             Files = new Files(this);
             Images = new Images(this);

--- a/src/StreamClientOptions.cs
+++ b/src/StreamClientOptions.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Net.Http;
+
 namespace Stream
 {
     /// <summary>Customization options for the internal HTTP client.</summary>
@@ -29,6 +32,20 @@ namespace Stream
         /// </summary>
         /// <remarks>Default is US East.</remarks>
         public StreamApiLocation PersonalizationLocation { get; set; } = StreamApiLocation.USEast;
+
+        /// <summary>
+        /// Middleware that wraps every HTTP request the client makes, letting you observe or
+        /// decorate requests and responses. The first handler in the list is the outermost one:
+        /// it sees the request first and the response last.
+        /// </summary>
+        /// <remarks>
+        /// A handler receives the raw <see cref="HttpResponseMessage"/>, so it can read response
+        /// headers the SDK does not surface itself, such as the rate limit headers described at
+        /// https://getstream.io/docs/platform/rate-limits/.
+        /// <para>Handler instances are bound to the client they are passed to, so give every
+        /// <see cref="StreamClient"/> its own handler instances.</para>
+        /// </remarks>
+        public IList<DelegatingHandler> HttpHandlers { get; } = new List<DelegatingHandler>();
     }
 
     /// <summary>Physical location of the backend.</summary>

--- a/tests/HttpHandlerTests.cs
+++ b/tests/HttpHandlerTests.cs
@@ -1,0 +1,234 @@
+using NUnit.Framework;
+using Stream;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace StreamNetTests
+{
+    [TestFixture]
+    public class HttpHandlerTests
+    {
+        private const long ResetTimestamp = 1717171717;
+
+        [Test]
+        public async Task RateLimitHandlerReadsRateLimitHeaders()
+        {
+            var rateLimits = new RateLimitHandler();
+            var client = ClientWith(rateLimits, StubHandler.Ok());
+
+            await client.Feed("flat", "userid").GetActivitiesAsync();
+
+            Assert.AreEqual(5000, rateLimits.Current.Limit);
+            Assert.AreEqual(4999, rateLimits.Current.Remaining);
+            Assert.AreEqual(DateTimeOffset.FromUnixTimeSeconds(ResetTimestamp), rateLimits.Current.Reset);
+        }
+
+        [Test]
+        public async Task RateLimitHandlerInvokesCallbackPerResponse()
+        {
+            var observed = new List<StreamRateLimits>();
+            var client = ClientWith(new RateLimitHandler(observed.Add), StubHandler.Ok());
+            var feed = client.Feed("flat", "userid");
+
+            await feed.GetActivitiesAsync();
+            await feed.GetActivitiesAsync();
+
+            Assert.AreEqual(2, observed.Count);
+            Assert.AreEqual(4999, observed[0].Remaining);
+            Assert.AreEqual(4999, observed[1].Remaining);
+        }
+
+        [Test]
+        public async Task RateLimitHandlerReportsNothingWhenHeadersAreAbsent()
+        {
+            var rateLimits = new RateLimitHandler();
+            var client = ClientWith(rateLimits, StubHandler.WithoutRateLimitHeaders());
+
+            await client.Feed("flat", "userid").GetActivitiesAsync();
+
+            Assert.IsNull(rateLimits.Current);
+        }
+
+        [Test]
+        public async Task HandlersSeeTheOutgoingRequest()
+        {
+            var stub = StubHandler.Ok();
+            var client = ClientWith(stub);
+
+            await client.Feed("flat", "userid").GetActivitiesAsync();
+
+            Assert.AreEqual(HttpMethod.Get, stub.LastRequest.Method);
+            StringAssert.Contains("/feed/flat/userid/", stub.LastRequest.RequestUri.AbsolutePath);
+            Assert.IsTrue(stub.LastRequest.Headers.Contains("Authorization"));
+        }
+
+        [Test]
+        public async Task HandlersRunOutermostFirst()
+        {
+            var calls = new List<string>();
+            var client = ClientWith(new RecordingHandler("outer", calls), new RecordingHandler("inner", calls), StubHandler.Ok());
+
+            await client.Feed("flat", "userid").GetActivitiesAsync();
+
+            Assert.AreEqual(new[] { "outer:request", "inner:request", "inner:response", "outer:response" }, calls);
+        }
+
+        [Test]
+        public void NoHandlersAreRegisteredByDefault()
+        {
+            Assert.IsEmpty(StreamClientOptions.Default.HttpHandlers);
+        }
+
+        private static IStreamClient ClientWith(params DelegatingHandler[] handlers)
+        {
+            var options = new StreamClientOptions();
+            foreach (var handler in handlers)
+            {
+                options.HttpHandlers.Add(handler);
+            }
+
+            return new StreamClient("apikey", "apisecret", options);
+        }
+
+        // Terminal handler: answers with a canned response so no request leaves the machine.
+        private class StubHandler : DelegatingHandler
+        {
+            private readonly bool _withRateLimitHeaders;
+
+            private StubHandler(bool withRateLimitHeaders)
+            {
+                _withRateLimitHeaders = withRateLimitHeaders;
+            }
+
+            public HttpRequestMessage LastRequest { get; private set; }
+
+            public static StubHandler Ok() => new StubHandler(true);
+
+            public static StubHandler WithoutRateLimitHeaders() => new StubHandler(false);
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastRequest = request;
+
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"results\":[]}"),
+                };
+
+                if (_withRateLimitHeaders)
+                {
+                    response.Headers.Add("X-RateLimit-Limit", "5000");
+                    response.Headers.Add("X-RateLimit-Remaining", "4999");
+                    response.Headers.Add("X-RateLimit-Reset", ResetTimestamp.ToString());
+                }
+
+                return Task.FromResult(response);
+            }
+        }
+
+        private class RecordingHandler : DelegatingHandler
+        {
+            private readonly string _name;
+            private readonly List<string> _calls;
+
+            public RecordingHandler(string name, List<string> calls)
+            {
+                _name = name;
+                _calls = calls;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                _calls.Add($"{_name}:request");
+                var response = await base.SendAsync(request, cancellationToken);
+                _calls.Add($"{_name}:response");
+                return response;
+            }
+        }
+    }
+
+    // Rate limit budget reported by the Stream API on a single response.
+    // See https://getstream.io/docs/platform/rate-limits/ for how Stream applies rate limits.
+    internal class StreamRateLimits
+    {
+        public StreamRateLimits(int limit, int remaining, DateTimeOffset reset)
+        {
+            Limit = limit;
+            Remaining = remaining;
+            Reset = reset;
+        }
+
+        public int Limit { get; }
+
+        public int Remaining { get; }
+
+        public DateTimeOffset Reset { get; }
+    }
+
+    // Sample handler proving StreamClientOptions.HttpHandlers can reach response headers the SDK
+    // does not surface itself. This is the handler the README documents users writing themselves,
+    // kept here so the extension point stays covered without shipping it as public API.
+    internal class RateLimitHandler : DelegatingHandler
+    {
+        private readonly Action<StreamRateLimits> _onResponse;
+        private volatile StreamRateLimits _current;
+
+        public RateLimitHandler(Action<StreamRateLimits> onResponse = null)
+        {
+            _onResponse = onResponse;
+        }
+
+        // Budget reported by the most recent response, or null until one carried the headers.
+        public StreamRateLimits Current => _current;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = await base.SendAsync(request, cancellationToken);
+
+            if (TryReadRateLimits(response.Headers, out var limits))
+            {
+                _current = limits;
+                _onResponse?.Invoke(limits);
+            }
+
+            return response;
+        }
+
+        private static bool TryReadRateLimits(HttpResponseHeaders headers, out StreamRateLimits limits)
+        {
+            limits = null;
+
+            if (!TryReadNumber(headers, "X-RateLimit-Limit", out var limit) ||
+                !TryReadNumber(headers, "X-RateLimit-Remaining", out var remaining) ||
+                !TryReadNumber(headers, "X-RateLimit-Reset", out var reset))
+            {
+                return false;
+            }
+
+            limits = new StreamRateLimits((int)limit, (int)remaining, DateTimeOffset.FromUnixTimeSeconds(reset));
+            return true;
+        }
+
+        private static bool TryReadNumber(HttpResponseHeaders headers, string name, out long value)
+        {
+            value = 0;
+
+            if (!headers.TryGetValues(name, out var values))
+                return false;
+
+            foreach (var candidate in values)
+            {
+                if (long.TryParse(candidate, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
The changes in this pull request would allow customers to extend their integrations. It could for example allow to monitor the rate limit response headers and use them for adequate early alerting when limits are about to be reached.